### PR TITLE
chore(ci): archive duplicate workflow daily.yml -> .github/archived_workflows

### DIFF
--- a/.github/archived_workflows/daily.yml
+++ b/.github/archived_workflows/daily.yml
@@ -1,0 +1,42 @@
+name: daily-updates
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 8 * * *'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    env:
+      PYTHONUNBUFFERED: '1'
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Cache pip
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          if [ -f requirements.txt ]; then
+            python -m pip install -r requirements.txt
+          else
+            python -m pip install requests
+          fi
+
+      - name: Run collector
+        run: |
+          python update_sweep.py


### PR DESCRIPTION
Motivo:
- Evitar ejecuciones duplicadas del pipeline.
- Mantener histórico del workflow antiguo para auditoría.

Cambios:
- Muevo .github/workflows/daily.yml -> .github/archived_workflows/daily.yml
- Mantengo activo .github/workflows/daily-updates.yml (instalación de deps y ejecución de update_sweep.py)

Checklist:
- [ ] Confirmar que daily-updates.yml contiene instalación de requirements.
- [ ] Ejecutar manualmente daily-updates después del merge (smoke test).
